### PR TITLE
[LeeJun]: additionalJS 문법 오류 해결

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -195,7 +195,7 @@
 
 
     <script type="text/javascript">
-        {% block additionalJS %} { % endblock %}
+        {% block additionalJS %} {% endblock %}
     </script>
     <script type="text/javascript" src="{% block js %}{% endblock %}">
         <!-- 필요 없는 부분입니다. -->


### PR DESCRIPTION
결제 페이지에서 기사 팝업 띄울 때 필요한 자바 스크립트 변수 선언문이 오류가 났었습니다.